### PR TITLE
Add GitHub Action for lint, and build

### DIFF
--- a/.github/workflow/build.yml
+++ b/.github/workflow/build.yml
@@ -1,0 +1,32 @@
+name: Build
+on: [pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Run ESLint
+        run: npx eslint . --ext .js,.jsx,.ts,.tsx
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+
+      - name: Install modules
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Added GitHub actions for **eslint** and **build** on every pull request
This Action is enabled for every branch PR. Later when merging it to the `main` branch, we can restrict it to the `main` branch only.

@eddiejaoude What do you think?

Closes #15 